### PR TITLE
Add reference points

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
                     <span class="input-group-text" style="width:5.5em">Azimuth</span>
                 </div>
                 <input id="input_art_azim" type="number" class="form-control" tabindex="101">
+                <input id="input_art_corr" type="number" class="form-control" tabindex="102" placeholder="Correction in m (negative=left, optional)" aria-label="Correction in m (negative=left, optional)">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
                     <button id="btn_swapcourse_art_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
@@ -89,6 +90,7 @@
                 <li>Have a spotter determine the distance and azimuth to the target location.</li>
                 <li>Without moving, have the spotter determine the distance and azimuth to the artillery location.</li>
                 <li>Input the two sets of values, and the computed result is the distance and azimuth from the artillery to the target.</li>
+                <li>The optional left/right correction can be entered as viewed from the gun in meters. Negative values indicate correction to the left.</li>
                 <li>Adjust the artillery settings to match the resulting values, then fire!</li>
                 <li>You can optionally insert linked Target Reference Points between the spotter and the arty, this allows for spotting beyond binocular range.</li>
             </ol>
@@ -100,8 +102,8 @@
         </section>
         <section id="sec_result">
             <h2 style="font-size:20pt">Result</h2>
-            <div id="raw_result_div"></div>
             <div id="est_result_div"></div>
+            <div id="raw_result_div" style="font-size:small"></div>
         </section>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
@@ -167,7 +169,18 @@
                     $("#est_result_div").html("");
                 }
                 else {
-                    $("#raw_result_div").html("Raw values: [Distance: " + (Math.round(result.art_tar_dist*100)/100) + ", Azimuth: " + (Math.round(result.art_tar_deg*100)/100) + "]");
+                    // apply optional correction
+                    var corr        = parseFloat($("#input_art_corr").val());
+                    var corr_1deg   = artycal.getOpAngleDist(result.art_tar_dist, 1.0);
+                    var corr_mToDeg = 0;
+                    if (!isNaN(corr)) {
+                        console.log("apply correction: %o", corr);
+                        corr_mToDeg = artycal.getCorrectionAngle(result.art_tar_dist, corr);
+                        result.art_tar_deg = result.art_tar_deg + corr_mToDeg;
+                    }
+                    
+                    // print results
+                    $("#raw_result_div").html("Raw values: [Distance: " + (Math.round(result.art_tar_dist*100)/100) + ", Azimuth: " + (Math.round((result.art_tar_deg-corr_mToDeg)*100)/100) + ", correction ("+Math.round(artycal.getOpAngleDist(result.art_tar_dist, 1.0)*100)/100+"m/1&deg;): "+((corr_mToDeg>0)?"+":"")+Math.round(corr_mToDeg*100)/100+"&deg;]");
                     var roundedResultAzim = Math.round(result.art_tar_deg);
                     if (roundedResultAzim == 360) roundedResultAzim = 0;
                     $("#est_result_div").html("<strong>In-game [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + roundedResultAzim + "]</strong>");
@@ -191,6 +204,7 @@
                 $("#input_tar_azim").val("");
                 $("#input_art_dist").val("");
                 $("#input_art_azim").val("");
+                $("#input_art_corr").val("");
                 for (var i=trp_list.length; i>0; i--) {
                     dropLastTRP();
                 };
@@ -341,7 +355,8 @@
                     },
                     art:{
                         dist:parseFloat($("#input_art_dist").val()),
-                        azim:parseFloat($("#input_art_azim").val())
+                        azim:parseFloat($("#input_art_azim").val()),
+                        corr:parseFloat($("#input_art_corr").val())
                     },
                     trps:[]
                 };
@@ -379,10 +394,15 @@
                 // restore spotter||trp -> arty leg
                 $("#input_art_dist").val(fp.art.dist);
                 $("#input_art_azim").val(fp.art.azim);
+                $("#input_art_corr").val(fp.art.corr);
                 
                 // when loading a firingplan, set it active
                 $("#firingplans_menu_btn").html(firingplans[id].name);
                 active_plan_id = id;
+                
+                // when loading a firingplan, clear previous results
+                $("#raw_result_div").html("");
+                $("#est_result_div").html("");
                 
                 updateFireplanSubmenuState();
             };

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
     <div class="container">
         <section>
             <h2>Target</h2>
-            <div class="input-group mb-3">
+            <div class="input-group mb-0">
                 <div class="input-group-prepend">
-                    <span class="input-group-text">Distance</span>
+                    <span class="input-group-text" style="width:5.5em">Distance</span>
                 </div>
                 <input id="input_tar_dist" type="number" class="form-control" tabindex="1" autofocus placeholder="from spotter to target" aria-label="from spotter to target">
                 <div class="input-group-append">
@@ -21,7 +21,7 @@
             </div>
             <div class="input-group mb-3">
                 <div class="input-group-prepend">
-                    <span class="input-group-text">Azimuth</span>
+                    <span class="input-group-text" style="width:5.5em">Azimuth</span>
                 </div>
                 <input id="input_tar_azim" type="number" class="form-control" tabindex="2" placeholder="from spotter to target" aria-label="from spotter to target">
                 <div class="input-group-append">
@@ -41,9 +41,9 @@
 
         <section>
             <h2>Artillery</h2>
-            <div class="input-group mb-3">
+            <div class="input-group mb-0">
                 <div class="input-group-prepend">
-                    <span class="input-group-text">Distance</span>
+                    <span class="input-group-text" style="width:5.5em">Distance</span>
                 </div>
                 <input id="input_art_dist" type="number" class="form-control" tabindex="100">
                 <div class="input-group-append">
@@ -52,7 +52,7 @@
             </div>
             <div class="input-group mb-3">
                 <div class="input-group-prepend">
-                    <span class="input-group-text">Azimuth</span>
+                    <span class="input-group-text" style="width:5.5em">Azimuth</span>
                 </div>
                 <input id="input_art_azim" type="number" class="form-control" tabindex="101">
                 <div class="input-group-append">
@@ -266,9 +266,9 @@
                 // prepare simple HTML template
                 var html_template = `<section id="trp_{newTRPid}">
                         <h2>Target Reference Point (TRP) #{newTRPid}</h2>
-                        <div class="input-group mb-3">
+                        <div class="input-group mb-0">
                             <div class="input-group-prepend">
-                                <span class="input-group-text">Distance</span>
+                                <span class="input-group-text" style="width:5.5em">Distance</span>
                             </div>
                             <input id="input_trp_{newTRPid}_dist" type="number" placeholder="-" class="form-control" aria-label="-" tabindex="{tabindex_dist}">
                             <div class="input-group-append">
@@ -277,7 +277,7 @@
                         </div>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend">
-                                <span class="input-group-text">Azimuth</span>
+                                <span class="input-group-text" style="width:5.5em">Azimuth</span>
                             </div>
                             <input id="input_trp_{newTRPid}_azim" type="number" placeholder="-" class="form-control" aria-label="-" tabindex="{tabindex_azim}">
                             <div class="input-group-append">

--- a/index.html
+++ b/index.html
@@ -249,6 +249,14 @@
                 $(this).select();
             });
             
+            /* Iput fields try to calculate when hitting ENTER */
+            $("#input_tar_dist").keyup(function(e){       if(e.which == 13)  $("#btn_compute").click();  });
+            $("#input_tar_azim").keyup(function(e){       if(e.which == 13)  $("#btn_compute").click();  });
+            $("#input_art_dist").keyup(function(e){       if(e.which == 13)  $("#btn_compute").click();  });
+            $("#input_art_azim").keyup(function(e){       if(e.which == 13)  $("#btn_compute").click();  });
+            $("#input_art_corr_dir").keyup(function(e){   if(e.which == 13)  $("#btn_compute").click();  });
+            $("#input_art_corr_dist").keyup(function(e){  if(e.which == 13)  $("#btn_compute").click();  });
+            
             
             
             /***********************
@@ -335,6 +343,8 @@
                     var backcourse = artycal.get_backcourse( parseFloat($("#input_trp_"+newTRPid+"_azim").val()) );
                     $("#input_trp_"+newTRPid+"_azim").val( backcourse );
                 });
+                $("#input_trp_"+newTRPid+"_dist").keyup(function(e){  if(e.which == 13)  $("#btn_compute").click();  });
+                $("#input_trp_"+newTRPid+"_azim").keyup(function(e){  if(e.which == 13)  $("#btn_compute").click();  });
                 
                 $("#input_trp_"+newTRPid+"_dist").focus();
                 

--- a/index.html
+++ b/index.html
@@ -50,18 +50,28 @@
                     <span class="input-group-text">meters</span>
                 </div>
             </div>
-            <div class="input-group mb-3">
+            <div class="input-group mb-0">
                 <div class="input-group-prepend">
                     <span class="input-group-text" style="width:5.5em">Azimuth</span>
                 </div>
                 <input id="input_art_azim" type="number" class="form-control" tabindex="101">
-                <input id="input_art_corr" type="number" class="form-control" tabindex="102" placeholder="Correction in m (negative=left, optional)" aria-label="Correction in m (negative=left, optional)">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
                     <button id="btn_swapcourse_art_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
                 </div>
             </div>
+            <div class="input-group mb-3">
+                <div class="input-group-prepend">
+                    <span class="input-group-text" style="width:5.5em">Correction</span>
+                </div>
+                <input id="input_art_corr_dir" type="number" class="form-control" tabindex="102" placeholder="X Correction left/right in m (negative=left, optional)" aria-label="Correction in m (negative=left, optional)">
+                <input id="input_art_corr_dist" type="number" class="form-control" tabindex="103" placeholder="Y Correction short/add in m (negative=short, optional)" aria-label="Correction in m (negative=left, optional)">
+                <div class="input-group-append">
+                    <span class="input-group-text">meters (viewed from spotter)</span>
+                </div>
+            </div>
         </section>
+
         <section>
             <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="110">Compute</button>
             <button id="btn_clear_tar" type="button" class="btn btn-outline-secondary">Clear Target</button>
@@ -90,14 +100,14 @@
                 <li>Have a spotter determine the distance and azimuth to the target location.</li>
                 <li>Without moving, have the spotter determine the distance and azimuth to the artillery location.</li>
                 <li>Input the two sets of values, and the computed result is the distance and azimuth from the artillery to the target.</li>
-                <li>The optional left/right correction can be entered as viewed from the gun in meters. Negative values indicate correction to the left.</li>
+                <li>The optional left/right and drop/add correction can be entered as viewed from the spotter in meters. Negative values indicate correction to the left/closer to the spotter.</li>
                 <li>Adjust the artillery settings to match the resulting values, then fire!</li>
                 <li>You can optionally insert linked Target Reference Points between the spotter and the arty, this allows for spotting beyond binocular range.</li>
             </ol>
             <p>The <strong>In-game values</strong> in the result are rounded to match the in-game increments.</p>
-            <p>You can save firing plans for later use. To do this, add a new plan from the menu and enter a name. The current state will be persisted
+            <p>You can save <b>firing plans</b> for later use. To do this, add a new plan from the menu and enter a name. The current state will be persisted
             and can be reloaded by selecting it form the firing plan menu. The currently active plan is displayed and by pressing the button,
-            you can reset the current values to the stored ones.</p>
+            you can reset the current values to the stored ones. Note that the correction portion is <i>not</i> restored.</p>
             <p>Please report bugs and suggestions <a href="https://github.com/earthgrazer/foxhole-artillery-calc/issues" target="_blank">here</a>.</p>
         </section>
         <section id="sec_result">
@@ -160,7 +170,25 @@
                     
                 }
 
-                // Calculate vector from arty->spotters target.
+                // Optionally apply correction.
+                // We do this by calculating a "hidden TRP" which reflects the correction as viewed from the forward observer.
+                var corr_x = parseFloat($("#input_art_corr_dir").val());  if (isNaN(corr_x)) corr_x=0;
+                var corr_y = parseFloat($("#input_art_corr_dist").val()); if (isNaN(corr_y)) corr_y=0;
+                var corr_vector = artycal.cartesianToPolar(0, 0, corr_x, corr_y);
+
+                // the correction vector is relative to the spotters front (0°=straight in front); so we need to convert to "true north"
+                corr_vector.azim = tar_azim + corr_vector.azim;
+                if (corr_vector.azim > 360) corr_vector.azim = corr_vector.azim - 360;
+                if (corr_vector.azim <   0) corr_vector.azim = corr_vector.azim + 360;
+
+                // apply correction to final result
+                //console.log("correction vector: (%o) %o", {x:corr_x, y:corr_y}, corr_vector);
+                var intermediate_vector = artycal.calc_artillery(corr_vector.dist, corr_vector.azim, art_dist, art_azim);
+                art_dist = intermediate_vector.art_tar_dist;
+                art_azim = artycal.get_backcourse(intermediate_vector.art_tar_deg);
+
+
+                // Calculate corrected vector from arty->spotters target.
                 // Either that is directly that from the spotter, or the resolved intermediate_vector from the TRP chain
                 var result = artycal.calc_artillery(tar_dist, tar_azim, art_dist, art_azim);
 
@@ -169,18 +197,11 @@
                     $("#est_result_div").html("");
                 }
                 else {
-                    // apply optional correction
-                    var corr        = parseFloat($("#input_art_corr").val());
-                    var corr_1deg   = artycal.getOpAngleDist(result.art_tar_dist, 1.0);
-                    var corr_mToDeg = 0;
-                    if (!isNaN(corr)) {
-                        console.log("apply correction: %o", corr);
-                        corr_mToDeg = artycal.getCorrectionAngle(result.art_tar_dist, corr);
-                        result.art_tar_deg = result.art_tar_deg + corr_mToDeg;
-                    }
-                    
                     // print results
-                    $("#raw_result_div").html("Raw values: [Distance: " + (Math.round(result.art_tar_dist*100)/100) + ", Azimuth: " + (Math.round((result.art_tar_deg-corr_mToDeg)*100)/100) + ", correction ("+Math.round(artycal.getOpAngleDist(result.art_tar_dist, 1.0)*100)/100+"m/1&deg;): "+((corr_mToDeg>0)?"+":"")+Math.round(corr_mToDeg*100)/100+"&deg;]");
+                    var correction_str = (corr_x != 0 || corr_y != 0)? " =&gt; "+(Math.round(corr_vector.dist*100)/100)+"m/"+(Math.round(corr_vector.azim*100)/100)+"&deg;" : "";
+                    $("#raw_result_div").html("Raw values: [Distance: " + (Math.round(result.art_tar_dist*100)/100) + ", Azimuth: " + (Math.round((result.art_tar_deg)*100)/100)
+                        + " (correction: "+Math.round(artycal.getOpAngleDist(result.art_tar_dist, 1.0)*100)/100+"m/1&deg;"+correction_str+")"
+                        + "]");
                     var roundedResultAzim = Math.round(result.art_tar_deg);
                     if (roundedResultAzim == 360) roundedResultAzim = 0;
                     $("#est_result_div").html("<strong>In-game [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + roundedResultAzim + "]</strong>");
@@ -204,7 +225,8 @@
                 $("#input_tar_azim").val("");
                 $("#input_art_dist").val("");
                 $("#input_art_azim").val("");
-                $("#input_art_corr").val("");
+                $("#input_art_corr_dir").val("");
+                $("#input_art_corr_dist").val("");
                 for (var i=trp_list.length; i>0; i--) {
                     dropLastTRP();
                 };
@@ -356,7 +378,10 @@
                     art:{
                         dist:parseFloat($("#input_art_dist").val()),
                         azim:parseFloat($("#input_art_azim").val()),
-                        corr:parseFloat($("#input_art_corr").val())
+                        corr:{
+                            dir:parseFloat($("#input_art_corr_dir").val()),
+                            dist:parseFloat($("#input_art_corr_dist").val())
+                        }
                     },
                     trps:[]
                 };
@@ -394,7 +419,10 @@
                 // restore spotter||trp -> arty leg
                 $("#input_art_dist").val(fp.art.dist);
                 $("#input_art_azim").val(fp.art.azim);
-                $("#input_art_corr").val(fp.art.corr);
+                
+                // Do not restore correction: its depending on wind
+                //$("#input_art_corr_dir").val(fp.art.corr.dir);
+                //$("#input_art_corr_dist").val(fp.art.corr.dist);
                 
                 // when loading a firingplan, set it active
                 $("#firingplans_menu_btn").html(firingplans[id].name);

--- a/index.html
+++ b/index.html
@@ -65,6 +65,21 @@
             <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="60">Compute</button>
             <button id="btn_clear_tar" type="button" class="btn btn-outline-secondary">Clear Target</button>
             <button id="btn_clear" type="button" class="btn btn-outline-secondary">Clear All</button>
+            |
+            <div class="btn-group dropup" id="firingplans_dropdown">
+                <button type="button" class="btn btn-outline-dark" id="firingplans_menu_btn">Firing plans</button>
+                <button type="button" class="btn btn-outline-dark dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-expanded="false">
+                    <span class="sr-only">Toggle Dropdown</span>
+                </button>
+                <div class="dropdown-menu" id="firingplans_menu">
+                    <button class="dropdown-item" type="button" id="firingplans_menu_add">Add new plan</button>
+                    <button class="dropdown-item" type="button" id="firingplans_menu_save">Save current plan</button>
+                    <button class="dropdown-item" type="button" id="firingplans_menu_del">Delete current plan</button>
+                    <div class="dropdown-divider"></div>
+                </div>
+                <input id="firingplans_add_input" type="text" class="form-control" placeholder="input name, confirm [enter]" aria-label="input name, confirm [enter]">
+            </div>
+            |
             <button id="btn_info" type="button" class="btn btn-outline-info">Info</button>
         </section>
         <section id="sec_info">
@@ -78,6 +93,9 @@
                 <li>You can optionally insert linked Target Reference Points between the spotter and the arty, this allows for spotting beyond binocular range.</li>
             </ol>
             <p>The <strong>In-game values</strong> in the result are rounded to match the in-game increments.</p>
+            <p>You can save firing plans for later use. To do this, add a new plan from the menu and enter a name. The current state will be persisted
+            and can be reloaded by selecting it form the firing plan menu. The currently active plan is displayed and by pressing the button,
+            you can reset the current values the stored ones.</p>
             <p>Please report bugs and suggestions <a href="https://github.com/earthgrazer/foxhole-artillery-calc/issues" target="_blank">here</a>.</p>
         </section>
         <section id="sec_result">
@@ -86,10 +104,8 @@
             <div id="est_result_div"></div>
         </section>
     </div>
-    <script
-            src="https://code.jquery.com/jquery-3.2.1.slim.min.js"
-            integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g="
-            crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
     <script type="text/javascript" src="./js/artycalc.js"></script>
     <script type="text/javascript">
         $(document).ready(function() {
@@ -178,6 +194,9 @@
                 for (var i=trp_list.length; i>0; i--) {
                     dropLastTRP();
                 };
+                active_plan_id = -1;
+                $("#firingplans_menu_btn").html("Firing plans");
+                updateFireplanSubmenuState();
             });
 
             $("#btn_clear_tar").click(function() {
@@ -276,6 +295,202 @@
                 dropLastTRP();
             });
             
+            
+            
+            /****************************
+            * Load/save/del firing plan *
+            ****************************/
+            
+            // init stored plans
+            const firingplans_storagename = "foxhole-artillery-calc_firingplans";
+            var firingplans = JSON.parse(localStorage.getItem(firingplans_storagename));
+            if (firingplans == null) firingplans = [];
+            $("#firingplans_add_input").hide();
+            var active_plan_id = -1;
+            
+            // Function stores cleaned version of the data array
+            var persist_firingplans = function() {
+                var firingplans_clean = firingplans.filter(data => data != null);
+                localStorage.setItem(firingplans_storagename, JSON.stringify(firingplans_clean));
+                //console.log("persisted: %o", firingplans_clean);
+            };
+            
+            // Function makes new fireplan structure based on current input state
+            var newFireplanFromcurrent = function(name) {
+                var fp_struct =
+                {
+                    name:name,
+                    tgt:{
+                        dist:parseFloat($("#input_tar_dist").val()),
+                        azim:parseFloat($("#input_tar_azim").val())
+                    },
+                    art:{
+                        dist:parseFloat($("#input_art_dist").val()),
+                        azim:parseFloat($("#input_art_azim").val())
+                    },
+                    trps:[]
+                };
+                
+                // add optional TRPs
+                for (var i=0; i<trp_list.length; i++) {
+                    var trp_idx = trp_list[i];
+                    fp_struct.trps.push({
+                        id:trp_idx,
+                        dist:parseFloat($("#input_trp_"+trp_idx+"_dist").val()),
+                        azim:parseFloat($("#input_trp_"+trp_idx+"_azim").val())
+                    });
+                }
+                
+                return fp_struct;
+            };
+            
+            // loads a given firingplan to the input fields
+            var loadFiringplan = function(id) {
+                var fp = firingplans[id];
+                //console.log("load fireplan: %i=%o", id, fp);
+                $("#btn_clear").click();  // clean out everything set so far
+                
+                // restore spotter->tgt leg
+                $("#input_tar_dist").val(fp.tgt.dist);
+                $("#input_tar_azim").val(fp.tgt.azim);
+                
+                // restore optional TRPs
+                for (var trp_idx=0; trp_idx<fp.trps.length; trp_idx++) {
+                    $('#btn_add_trp').click();
+                    $("#input_trp_"+ (trp_idx+1) +"_dist").val(fp.trps[trp_idx].dist);
+                    $("#input_trp_"+ (trp_idx+1) +"_azim").val(fp.trps[trp_idx].azim);
+                }
+                
+                // restore spotter||trp -> arty leg
+                $("#input_art_dist").val(fp.art.dist);
+                $("#input_art_azim").val(fp.art.azim);
+                
+                // when loading a firingplan, set it active
+                $("#firingplans_menu_btn").html(firingplans[id].name);
+                active_plan_id = id;
+                
+                updateFireplanSubmenuState();
+            };
+            
+            // Add a fireplan to the list and storage
+            // If newPlanID is not null, the storage is not adjusted and the given Id used as reference
+            // returns ID of the added plan
+            var globalUnique_newPlanID = firingplans.length;
+            var addFiringplan = function(fp, newPlanID=null) {
+                if (newPlanID == null) {
+                    newPlanID              = globalUnique_newPlanID++;
+                    firingplans[newPlanID] = fp;
+                    active_plan_id         = newPlanID;
+                    persist_firingplans();
+                    $("#firingplans_menu_btn").html(firingplans[newPlanID].name);
+                }
+                
+                $("#firingplans_menu").append("<button class=\"dropdown-item\" type=\"button\" id=\"firingplans_plan_"+newPlanID+"\">"+firingplans[newPlanID].name+"</button>");
+                $("#firingplans_plan_"+newPlanID).click(function(e){
+                    //console.log("Fireplan item clicked, active plan="+active_plan_id+"; newPlanID="+newPlanID+"; this_id=%o", $(this));
+                    loadFiringplan(newPlanID);
+                });
+                
+                return newPlanID;
+            }
+            
+            // Updates the menus accessibility
+            var updateFireplanSubmenuState = function() {
+                // visible per default
+                $("#firingplans_menu_add").removeAttr("disabled");
+                $("#firingplans_menu_del").removeAttr("disabled");
+                $("#firingplans_menu_save").removeAttr("disabled");
+                $(":button[id*=firingplans_plan_]").removeAttr("disabled");
+            
+                // no active plan selected: disable del and save buttons
+                // (note: also the case when no plan is stored at all)
+                var firingplans_clean = firingplans.filter(data => data != null);
+                //console.log("DBG: active = "+active_plan_id+"; l="+firingplans_clean.length);
+                if (active_plan_id < 0 || firingplans_clean.length == 0 ) {
+                    $("#firingplans_menu_del").attr("disabled","");
+                    $("#firingplans_menu_save").attr("disabled","");
+                }
+
+                // menu not accessible when input element is active
+                if ($("#firingplans_add_input").is(":visible")) {
+                    $("#firingplans_menu_add").attr("disabled","");
+                    $("#firingplans_menu_del").attr("disabled","");
+                    $("#firingplans_menu_save").attr("disabled","");
+                    $(":button[id*=firingplans_plan_]").attr("disabled","");
+                }
+                
+                // No save and del option when no firingplan is active
+                var firingplans_clean = firingplans.filter(data => data != null);
+                if (active_plan_id < 0) {
+                    $("#firingplans_menu_del").attr("disabled","");
+                    $("#firingplans_menu_save").attr("disabled","");
+                }
+            };
+            
+            
+            // Initialize dropdown values from stored content
+            //console.log("loading "+firingplans.length+" fireplans");
+            for (var i=0;i<firingplans.length; i++) {
+                addFiringplan(firingplans[i], i);
+                //console.log("  Fireplan "+i+": %o", firingplans[i]);
+            }
+            updateFireplanSubmenuState();
+            
+            // DropDown actions
+            $("#firingplans_menu_add").click(function() {
+                // add button shows the input field
+                $("#firingplans_add_input").show();
+                $("#firingplans_add_input").focus();
+                updateFireplanSubmenuState();
+            });
+            $("#firingplans_add_input").keyup(function(e){
+                // the input field reacts on enter and will store the new plan
+                if(e.which == 13){  //onEnter
+                    var fpname = $(this).val();
+                    if (fpname != null && fpname != "") {
+                        freshFireplan  = newFireplanFromcurrent(fpname);
+                        active_plan_id = addFiringplan(freshFireplan);
+                        loadFiringplan(active_plan_id);
+                        persist_firingplans();
+                    } else {
+                        //console.log("adding firingplan skipped: name empty");
+                    }
+                    
+                    // clean input field and hide it again
+                    $("#firingplans_add_input").val("");
+                    $("#firingplans_add_input").hide();
+                    updateFireplanSubmenuState();
+                }
+            });
+            
+            $("#firingplans_menu_save").click(function(){
+                if (active_plan_id > -1) {
+                    var fp = newFireplanFromcurrent(firingplans[active_plan_id].name);
+                    firingplans[active_plan_id] = fp;
+                    updateFireplanSubmenuState();
+                    persist_firingplans();
+                }
+            });
+            
+            $("#firingplans_menu_del").click(function(){
+                if (active_plan_id > -1) {
+                    firingplans[active_plan_id] = null;
+                    $("#firingplans_plan_"+active_plan_id).remove();
+                    active_plan_id = -1;
+                    $("#firingplans_menu_btn").html("Firing plans");
+                }
+                updateFireplanSubmenuState();
+                persist_firingplans();
+            });
+            
+            
+             $("#firingplans_menu_btn").click(function(){
+                //console.log("Fireplan BTN clicked");
+                if ( active_plan_id > -1) {
+                    loadFiringplan(active_plan_id);
+                    updateFireplanSubmenuState();
+                }
+             });
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
             <p>The <strong>In-game values</strong> in the result are rounded to match the in-game increments.</p>
             <p>You can save firing plans for later use. To do this, add a new plan from the menu and enter a name. The current state will be persisted
             and can be reloaded by selecting it form the firing plan menu. The currently active plan is displayed and by pressing the button,
-            you can reset the current values the stored ones.</p>
+            you can reset the current values to the stored ones.</p>
             <p>Please report bugs and suggestions <a href="https://github.com/earthgrazer/foxhole-artillery-calc/issues" target="_blank">here</a>.</p>
         </section>
         <section id="sec_result">

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
                 <input id="input_tar_azim" type="number" placeholder="from spotter to target" class="form-control" aria-label="from spotter to target" tabindex="2">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
+                    <button id="btn_swapcourse_tar_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
                 </div>
             </div>
         </section>
@@ -47,6 +48,7 @@
                 <input id="input_art_azim" type="number" placeholder="from spotter to artillery" class="form-control" aria-label="from spotter to artillery" tabindex="4">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
+                    <button id="btn_swapcourse_art_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
                 </div>
             </div>
         </section>
@@ -102,6 +104,15 @@
 
                 $("#sec_result").show();
                 $("#sec_info").hide();
+            });
+            
+            $('#btn_swapcourse_tar_azim').click(function() {
+                var backcourse = artycal.get_backcourse( parseFloat($("#input_tar_azim").val()) );
+                $("#input_tar_azim").val( backcourse );
+            });
+            $('#btn_swapcourse_art_azim').click(function() {
+                var backcourse = artycal.get_backcourse( parseFloat($("#input_art_azim").val()) );
+                $("#input_art_azim").val( backcourse );
             });
 
             $("#btn_clear").click(function() {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">Distance</span>
                 </div>
-                <input id="input_tar_dist" type="number" placeholder="from spotter to target" class="form-control" aria-label="from spotter to target" tabindex="1" autofocus>
+                <input id="input_tar_dist" type="number" class="form-control" tabindex="1" autofocus placeholder="from spotter to target" aria-label="from spotter to target">
                 <div class="input-group-append">
                     <span class="input-group-text">meters</span>
                 </div>
@@ -23,20 +23,29 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">Azimuth</span>
                 </div>
-                <input id="input_tar_azim" type="number" placeholder="from spotter to target" class="form-control" aria-label="from spotter to target" tabindex="2">
+                <input id="input_tar_azim" type="number" class="form-control" tabindex="2" placeholder="from spotter to target" aria-label="from spotter to target">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
                     <button id="btn_swapcourse_tar_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
                 </div>
             </div>
         </section>
+
+        <section>
+            <hr/>
+            <div id="container_additional_trps"><!-- TODO: New TRPs go here --></div>
+            <button id="btn_add_trp" class="btn btn-secondary btn-sm">+ Add Target Reference Point</button>
+            <button id="btn_del_trp" class="btn btn-outline-danger btn-sm">- remove Target Reference Point</button>
+            <hr/>
+        </section>
+
         <section>
             <h2>Artillery</h2>
             <div class="input-group mb-3">
                 <div class="input-group-prepend">
                     <span class="input-group-text">Distance</span>
                 </div>
-                <input id="input_art_dist" type="number" placeholder="from spotter to artillery" class="form-control" aria-label="from spotter to artillery" tabindex="3">
+                <input id="input_art_dist" type="number" class="form-control" tabindex="50">
                 <div class="input-group-append">
                     <span class="input-group-text">meters</span>
                 </div>
@@ -45,7 +54,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">Azimuth</span>
                 </div>
-                <input id="input_art_azim" type="number" placeholder="from spotter to artillery" class="form-control" aria-label="from spotter to artillery" tabindex="4">
+                <input id="input_art_azim" type="number" class="form-control" tabindex="51">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
                     <button id="btn_swapcourse_art_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
@@ -53,7 +62,7 @@
             </div>
         </section>
         <section>
-            <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="5">Compute</button>
+            <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="60">Compute</button>
             <button id="btn_clear_tar" type="button" class="btn btn-outline-secondary">Clear Target</button>
             <button id="btn_clear" type="button" class="btn btn-outline-secondary">Clear All</button>
             <button id="btn_info" type="button" class="btn btn-outline-info">Info</button>
@@ -66,6 +75,7 @@
                 <li>Without moving, have the spotter determine the distance and azimuth to the artillery location.</li>
                 <li>Input the two sets of values, and the computed result is the distance and azimuth from the artillery to the target.</li>
                 <li>Adjust the artillery settings to match the resulting values, then fire!</li>
+                <li>You can optionally insert linked Target Reference Points between the spotter and the arty, this allows for spotting beyond binocular range.</li>
             </ol>
             <p>The <strong>In-game values</strong> in the result are rounded to match the in-game increments.</p>
             <p>Please report bugs and suggestions <a href="https://github.com/earthgrazer/foxhole-artillery-calc/issues" target="_blank">here</a>.</p>
@@ -86,11 +96,54 @@
             $("#sec_result").hide();
 
             $("#btn_compute").click(function() {
+                // final leg spotter->tgt
                 var tar_dist = parseFloat($("#input_tar_dist").val());
                 var tar_azim = parseFloat($("#input_tar_azim").val());
+                
+                // leg spotter -> arty||trp1
                 var art_dist = parseFloat($("#input_art_dist").val());
                 var art_azim = parseFloat($("#input_art_azim").val());
+                
+                // Resolve optional TRPs in between and thus create a new big leg spotter->arty.
+                // We walk the TRPs from the arty to the target and resolve each new TRP into a
+                // iteratively growing final vector. All resolved intermediate vectors replace the last spotter->arty vector in the end.
+                // For the first TRP (as seen from arty) we need the vector, however subsequent lookups need the previuos intermediate_vector
+                // console.log("resolving "+trp_list.length+" TRPs");
+                for (var i=trp_list.length-1; i >= 0; i--) {
+                    // get this TRPs vector to the arty.
+                    // (for the nearest TRP this is its stored azimut, all others in the chain need the resolved intermediate_vector value)
+                    var trp_idx      = trp_list[i];
+                    var trp_art_dist = (i==trp_list.length-1)? parseFloat($("#input_trp_"+trp_idx+"_dist").val()) : art_dist;
+                    var trp_art_azim = (i==trp_list.length-1)? parseFloat($("#input_trp_"+trp_idx+"_azim").val()) : art_azim;
+                    // console.log("resolve TRP #"+trp_idx+":  trp_art_azim="+trp_art_azim+"; trp_art_azim="+trp_art_azim);
+                    
+                    // get vector from this TRP to the next one (either another TRP or original spotter->arty)
+                    var next_src     = (i>0)?  "#input_trp_"+trp_list[i-1] : "#input_art";
+                    var next_dist    = parseFloat($(next_src+"_dist").val());
+                    var next_azim_to = parseFloat($(next_src+"_azim").val());
+                    var next_azim    = artycal.get_backcourse(next_azim_to); // the data points towards us, but we need it to point from us to them
+                    // console.log("resolve TRP #"+trp_idx+":  next_dist="+next_dist+"; next_azim="+next_azim+" (backcourse from "+next_src+"_azim="+next_azim_to+")");
+                    
+                    // calculate dist+azim from arty to the next point
+                    var intermediate_vector = artycal.calc_artillery(next_dist, next_azim, trp_art_dist, trp_art_azim);
+                    if (intermediate_vector.hasOwnProperty("error")) {
+                        $("#raw_result_div").html("Error in TRP #"+trp_idx+" input value(s)");
+                        $("#est_result_div").html("");
+                        $("#sec_result").show();
+                        return;
+                    } else {
+                        // we now know the vector from the arty to the next spot.
+                        // the backcourse of that is what we need for the next (or final) resolving iteration.
+                        art_dist = intermediate_vector.art_tar_dist;
+                        art_azim = artycal.get_backcourse(intermediate_vector.art_tar_deg);
+                        // console.log("resolve TRP #"+trp_idx+":  new_art_dist="+art_dist+"; new_art_azim="+art_azim+" (intermediate_vector.art_tar_deg="+intermediate_vector.art_tar_deg+")");
+                    }
+                    
+                    
+                }
 
+                // Calculate vector from arty->spotters target.
+                // Either that is directly that from the spotter, or the resolved intermediate_vector from the TRP chain
                 var result = artycal.calc_artillery(tar_dist, tar_azim, art_dist, art_azim);
 
                 if (result.hasOwnProperty("error")) {
@@ -99,7 +152,9 @@
                 }
                 else {
                     $("#raw_result_div").html("Raw values: [Distance: " + result.art_tar_dist + ", Azimuth: " + result.art_tar_deg + "]");
-                    $("#est_result_div").html("<strong>In-game values: [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + Math.round(result.art_tar_deg) + "]</strong>");
+                    var roundedResultAzim = Math.round(result.art_tar_deg);
+                    if (roundedResultAzim == 360) roundedResultAzim = 0;
+                    $("#est_result_div").html("<strong>In-game values: [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + roundedResultAzim + "]</strong>");
                 }
 
                 $("#sec_result").show();
@@ -120,6 +175,9 @@
                 $("#input_tar_azim").val("");
                 $("#input_art_dist").val("");
                 $("#input_art_azim").val("");
+                for (var i=trp_list.length; i>0; i--) {
+                    dropLastTRP();
+                };
             });
 
             $("#btn_clear_tar").click(function() {
@@ -135,6 +193,89 @@
             $("input").focus(function() {
                 $(this).select();
             });
+            
+            
+            
+            /***********************
+            * TRP functionality    *
+            ************************/
+            let trp_list = []; // list of trp indexes
+            var update_trp_buttonstate = function() {
+                var m = "from spotter to artillery";
+                if (trp_list.length > 0) {
+                    var lasTRPIdx = trp_list[trp_list.length-1];
+                    $("#btn_del_trp").show();
+                    m = "from TRP #"+lasTRPIdx+" to artillery";
+                } else {
+                    $("#btn_del_trp").hide();
+                    var m = "from spotter to artillery";
+                }
+                $("#input_art_dist").attr("placeholder", m);
+                $("#input_art_dist").attr("aria-label", m);
+                $("#input_art_azim").attr("placeholder", m);
+                $("#input_art_azim").attr("aria-label", m);
+            };
+            update_trp_buttonstate();
+            
+            var dropLastTRP = function() {
+                var lastID =  trp_list.pop();
+                $("#trp_"+lastID).remove();
+                update_trp_buttonstate();
+            }
+            
+            $('#btn_add_trp').click(function() {
+                // Adds a new TRP to the selection
+                var prevTRPid     = trp_list[trp_list.length - 1];
+                var prevTRPid_txt = (prevTRPid)? "TRP #"+prevTRPid : "spotter";
+                var newTRPid      = trp_list.length + 1;
+                trp_list.push(newTRPid);
+                
+                // prepare simple HTML template
+                var html_template = `<section id="trp_{newTRPid}">
+                        <h2>Target Reference Point (TRP) #{newTRPid}</h2>
+                        <div class="input-group mb-3">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">Distance</span>
+                            </div>
+                            <input id="input_trp_{newTRPid}_dist" type="number" placeholder="from {prevTRPid_txt} to TRP #{newTRPid}" class="form-control" aria-label="from {prevTRPid_txt} to TRP #{newTRPid}" tabindex="{tabindex_dist}">
+                            <div class="input-group-append">
+                                <span class="input-group-text">meters</span>
+                            </div>
+                        </div>
+                        <div class="input-group mb-3">
+                            <div class="input-group-prepend">
+                                <span class="input-group-text">Azimuth</span>
+                            </div>
+                            <input id="input_trp_{newTRPid}_azim" type="number" placeholder="from {prevTRPid_txt} to TRP #{newTRPid}" class="form-control" aria-label="from {prevTRPid_txt} to TRP #{newTRPid}" tabindex="{tabindex_azim}">
+                            <div class="input-group-append">
+                                <span class="input-group-text">degrees</span>
+                                <button id="btn_swapcourse_trp_{newTRPid}_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
+                            </div>
+                        </div>
+                    </section>
+                `;
+                // replace variables in the template and
+                // finally add templated HTML container for the TRP
+                html_template = html_template.replace(/{prevTRPid}/g,     prevTRPid);
+                html_template = html_template.replace(/{prevTRPid_txt}/g, prevTRPid_txt);
+                html_template = html_template.replace(/{newTRPid}/g,      newTRPid);
+                html_template = html_template.replace(/{tabindex_dist}/g, newTRPid+10);
+                html_template = html_template.replace(/{tabindex_azim}/g, newTRPid+11);
+                $("#container_additional_trps").append(html_template);
+                
+                $("#btn_swapcourse_trp_"+newTRPid+"_azim").click(function() {
+                    var backcourse = artycal.get_backcourse( parseFloat($("#input_trp_"+newTRPid+"_azim").val()) );
+                    $("#input_trp_"+newTRPid+"_azim").val( backcourse );
+                });
+                
+                update_trp_buttonstate();
+            });
+            
+            
+            $("#btn_del_trp").click(function() {
+                dropLastTRP();
+            });
+            
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text" style="width:5.5em">Correction</span>
                 </div>
-                <input id="input_art_corr_dir" type="number" class="form-control" tabindex="102" placeholder="X Correction left/right in m (negative=left, optional)" aria-label="Correction in m (negative=left, optional)">
-                <input id="input_art_corr_dist" type="number" class="form-control" tabindex="103" placeholder="Y Correction short/add in m (negative=short, optional)" aria-label="Correction in m (negative=left, optional)">
+                <input id="input_art_corr_dir" type="number" class="form-control" tabindex="102" placeholder="left/right in m (negative=left, optional)" aria-label="left/right Correction in m (negative=left, optional)">
+                <input id="input_art_corr_dist" type="number" class="form-control" tabindex="103" placeholder="short/add in m (negative=short, optional)" aria-label="short/add Correction in m (negative=short, optional)">
                 <div class="input-group-append">
                     <span class="input-group-text">meters (viewed from spotter)</span>
                 </div>

--- a/index.html
+++ b/index.html
@@ -33,9 +33,9 @@
 
         <section>
             <hr/>
-            <div id="container_additional_trps"><!-- TODO: New TRPs go here --></div>
             <button id="btn_add_trp" class="btn btn-secondary btn-sm">+ Add Target Reference Point</button>
             <button id="btn_del_trp" class="btn btn-outline-danger btn-sm">- remove Target Reference Point</button>
+            <div id="container_additional_trps"><!-- Info: New TRPs stack up here --></div>
             <hr/>
         </section>
 
@@ -45,7 +45,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">Distance</span>
                 </div>
-                <input id="input_art_dist" type="number" class="form-control" tabindex="50">
+                <input id="input_art_dist" type="number" class="form-control" tabindex="100">
                 <div class="input-group-append">
                     <span class="input-group-text">meters</span>
                 </div>
@@ -54,7 +54,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">Azimuth</span>
                 </div>
-                <input id="input_art_azim" type="number" class="form-control" tabindex="51">
+                <input id="input_art_azim" type="number" class="form-control" tabindex="101">
                 <div class="input-group-append">
                     <span class="input-group-text">degrees</span>
                     <button id="btn_swapcourse_art_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
@@ -62,7 +62,7 @@
             </div>
         </section>
         <section>
-            <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="60">Compute</button>
+            <button id="btn_compute" type="button" class="btn btn-outline-primary" tabindex="110">Compute</button>
             <button id="btn_clear_tar" type="button" class="btn btn-outline-secondary">Clear Target</button>
             <button id="btn_clear" type="button" class="btn btn-outline-secondary">Clear All</button>
             |
@@ -125,16 +125,16 @@
                 // iteratively growing final vector. All resolved intermediate vectors replace the last spotter->arty vector in the end.
                 // For the first TRP (as seen from arty) we need the vector, however subsequent lookups need the previuos intermediate_vector
                 // console.log("resolving "+trp_list.length+" TRPs");
-                for (var i=trp_list.length-1; i >= 0; i--) {
+                for (var i=0; i<trp_list.length; i++) {
                     // get this TRPs vector to the arty.
                     // (for the nearest TRP this is its stored azimut, all others in the chain need the resolved intermediate_vector value)
                     var trp_idx      = trp_list[i];
-                    var trp_art_dist = (i==trp_list.length-1)? parseFloat($("#input_trp_"+trp_idx+"_dist").val()) : art_dist;
-                    var trp_art_azim = (i==trp_list.length-1)? parseFloat($("#input_trp_"+trp_idx+"_azim").val()) : art_azim;
+                    var trp_art_dist = (i==0)? parseFloat($("#input_trp_"+trp_idx+"_dist").val()) : art_dist;
+                    var trp_art_azim = (i==0)? parseFloat($("#input_trp_"+trp_idx+"_azim").val()) : art_azim;
                     // console.log("resolve TRP #"+trp_idx+":  trp_art_azim="+trp_art_azim+"; trp_art_azim="+trp_art_azim);
                     
                     // get vector from this TRP to the next one (either another TRP or original spotter->arty)
-                    var next_src     = (i>0)?  "#input_trp_"+trp_list[i-1] : "#input_art";
+                    var next_src     = (i<trp_list.length-1)?  "#input_trp_"+trp_list[i+1] : "#input_art";
                     var next_dist    = parseFloat($(next_src+"_dist").val());
                     var next_azim_to = parseFloat($(next_src+"_azim").val());
                     var next_azim    = artycal.get_backcourse(next_azim_to); // the data points towards us, but we need it to point from us to them
@@ -220,9 +220,24 @@
             ************************/
             let trp_list = []; // list of trp indexes
             var update_trp_buttonstate = function() {
+                // update TRPs texts
+                for (var i=0; i<trp_list.length; i++) {
+                    var m = "-";
+                    if (i==trp_list.length-1) {
+                        m = "from spotter to TRP #"+trp_list[i];
+                    } else {
+                        m = "from TRP #"+trp_list[i+1]+" to TRP #"+trp_list[i];
+                    }
+                    $("#input_trp_"+trp_list[i]+"_dist").attr("placeholder", m);
+                    $("#input_trp_"+trp_list[i]+"_dist").attr("aria-label", m);
+                    $("#input_trp_"+trp_list[i]+"_azim").attr("placeholder", m);
+                    $("#input_trp_"+trp_list[i]+"_azim").attr("aria-label", m);
+                }
+            
+                // update arty text
                 var m = "from spotter to artillery";
                 if (trp_list.length > 0) {
-                    var lasTRPIdx = trp_list[trp_list.length-1];
+                    var lasTRPIdx = trp_list[0];
                     $("#btn_del_trp").show();
                     m = "from TRP #"+lasTRPIdx+" to artillery";
                 } else {
@@ -244,9 +259,8 @@
             
             $('#btn_add_trp').click(function() {
                 // Adds a new TRP to the selection
-                var prevTRPid     = trp_list[trp_list.length - 1];
-                var prevTRPid_txt = (prevTRPid)? "TRP #"+prevTRPid : "spotter";
-                var newTRPid      = trp_list.length + 1;
+                var prevTRPid     = trp_list[trp_list.length];
+                var newTRPid      = trp_list.length+1;
                 trp_list.push(newTRPid);
                 
                 // prepare simple HTML template
@@ -256,7 +270,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Distance</span>
                             </div>
-                            <input id="input_trp_{newTRPid}_dist" type="number" placeholder="from {prevTRPid_txt} to TRP #{newTRPid}" class="form-control" aria-label="from {prevTRPid_txt} to TRP #{newTRPid}" tabindex="{tabindex_dist}">
+                            <input id="input_trp_{newTRPid}_dist" type="number" placeholder="-" class="form-control" aria-label="-" tabindex="{tabindex_dist}">
                             <div class="input-group-append">
                                 <span class="input-group-text">meters</span>
                             </div>
@@ -265,7 +279,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">Azimuth</span>
                             </div>
-                            <input id="input_trp_{newTRPid}_azim" type="number" placeholder="from {prevTRPid_txt} to TRP #{newTRPid}" class="form-control" aria-label="from {prevTRPid_txt} to TRP #{newTRPid}" tabindex="{tabindex_azim}">
+                            <input id="input_trp_{newTRPid}_azim" type="number" placeholder="-" class="form-control" aria-label="-" tabindex="{tabindex_azim}">
                             <div class="input-group-append">
                                 <span class="input-group-text">degrees</span>
                                 <button id="btn_swapcourse_trp_{newTRPid}_azim" class="btn btn-outline-secondary" title="swap backcourse">&#x21c4;</button>
@@ -276,16 +290,17 @@
                 // replace variables in the template and
                 // finally add templated HTML container for the TRP
                 html_template = html_template.replace(/{prevTRPid}/g,     prevTRPid);
-                html_template = html_template.replace(/{prevTRPid_txt}/g, prevTRPid_txt);
                 html_template = html_template.replace(/{newTRPid}/g,      newTRPid);
-                html_template = html_template.replace(/{tabindex_dist}/g, newTRPid+10);
-                html_template = html_template.replace(/{tabindex_azim}/g, newTRPid+11);
-                $("#container_additional_trps").append(html_template);
+                html_template = html_template.replace(/{tabindex_dist}/g,  99-newTRPid);
+                html_template = html_template.replace(/{tabindex_azim}/g, 100-newTRPid);
+                $("#container_additional_trps").prepend(html_template);
                 
                 $("#btn_swapcourse_trp_"+newTRPid+"_azim").click(function() {
                     var backcourse = artycal.get_backcourse( parseFloat($("#input_trp_"+newTRPid+"_azim").val()) );
                     $("#input_trp_"+newTRPid+"_azim").val( backcourse );
                 });
+                
+                $("#input_trp_"+newTRPid+"_dist").focus();
                 
                 update_trp_buttonstate();
             });

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <section>
-            <h2>Target</h2>
+            <h2 style="font-size:20pt">Target</h2>
             <div class="input-group mb-0">
                 <div class="input-group-prepend">
                     <span class="input-group-text" style="width:5.5em">Distance</span>
@@ -40,7 +40,7 @@
         </section>
 
         <section>
-            <h2>Artillery</h2>
+            <h2 style="font-size:20pt">Artillery</h2>
             <div class="input-group mb-0">
                 <div class="input-group-prepend">
                     <span class="input-group-text" style="width:5.5em">Distance</span>
@@ -83,7 +83,7 @@
             <button id="btn_info" type="button" class="btn btn-outline-info">Info</button>
         </section>
         <section id="sec_info">
-            <h2>Information</h2>
+            <h2 style="font-size:20pt">Information</h2>
             <p>To use this calculator:</p>
             <ol>
                 <li>Have a spotter determine the distance and azimuth to the target location.</li>
@@ -99,7 +99,7 @@
             <p>Please report bugs and suggestions <a href="https://github.com/earthgrazer/foxhole-artillery-calc/issues" target="_blank">here</a>.</p>
         </section>
         <section id="sec_result">
-            <h2>Result</h2>
+            <h2 style="font-size:20pt">Result</h2>
             <div id="raw_result_div"></div>
             <div id="est_result_div"></div>
         </section>
@@ -167,10 +167,10 @@
                     $("#est_result_div").html("");
                 }
                 else {
-                    $("#raw_result_div").html("Raw values: [Distance: " + result.art_tar_dist + ", Azimuth: " + result.art_tar_deg + "]");
+                    $("#raw_result_div").html("Raw values: [Distance: " + (Math.round(result.art_tar_dist*100)/100) + ", Azimuth: " + (Math.round(result.art_tar_deg*100)/100) + "]");
                     var roundedResultAzim = Math.round(result.art_tar_deg);
                     if (roundedResultAzim == 360) roundedResultAzim = 0;
-                    $("#est_result_div").html("<strong>In-game values: [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + roundedResultAzim + "]</strong>");
+                    $("#est_result_div").html("<strong>In-game [Distance: " + artycal.roundTo5(result.art_tar_dist) + "m, Azimuth: " + roundedResultAzim + "]</strong>");
                 }
 
                 $("#sec_result").show();
@@ -265,7 +265,7 @@
                 
                 // prepare simple HTML template
                 var html_template = `<section id="trp_{newTRPid}">
-                        <h2>Target Reference Point (TRP) #{newTRPid}</h2>
+                        <h2 style="font-size:20pt">Target Reference Point (TRP) #{newTRPid}</h2>
                         <div class="input-group mb-0">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" style="width:5.5em">Distance</span>

--- a/js/artycalc.js
+++ b/js/artycalc.js
@@ -62,6 +62,41 @@ var artycal = (function() {
             return ceil;
         }
     };
+    
+    /**
+     * Compute polar vector
+     * 
+     * @returns {dist:dist, azim:azim}
+     */
+    inst.cartesianToPolar = function(xa, ya, xb, yb) {
+        // calculate distance from artillery to target
+        var dist = Math.sqrt(Math.pow(xa - xb, 2) + Math.pow(ya - yb, 2));
+        // calculate azimuth from artiller to target
+        var azim = 0;
+        if (dist > 0) {
+            azim = to_degrees(Math.asin(Math.abs(xb) / dist));
+        }
+
+        // adjust degrees based on what quadrant the target is located relative to the artillery
+        if (xb < 0 && yb >= 0) {
+            // Target is in second quadrant
+            azim = 360 - azim;
+        }
+        else if (xb < 0 && yb < 0) {
+            // Target is in third quadrant
+            azim = 180 + azim;
+        }
+        else if (xb >= 0 && yb < 0) {
+            // Target is in fourth quadrant
+            azim = 180 - azim;
+        }
+
+        if (isNaN(dist) || isNaN(azim)) {
+            return {error: true};
+        }
+
+        return {dist:dist, azim:azim};
+    }
 
     /**
      * Compute distance and azimuth from artillery to target given location information relative to a spotter.
@@ -84,34 +119,10 @@ var artycal = (function() {
         var translate_origin = get_translate_matrix(art_coord);
         apply_translate(tar_coord, translate_origin);
         apply_translate(art_coord, translate_origin);
-
-        // calculate distance from artillery to target
-        var art_tar_dist = Math.sqrt(Math.pow(art_coord.x - tar_coord.x, 2) + Math.pow(art_coord.y - tar_coord.y, 2));
-        // calculate azimuth from artiller to target
-        var art_tar_deg = 0;
-        if (art_tar_dist > 0) {
-            art_tar_deg = to_degrees(Math.asin(Math.abs(tar_coord.x) / art_tar_dist));
-        }
-
-        // adjust degrees based on what quadrant the target is located relative to the artillery
-        if (tar_coord.x < 0 && tar_coord.y >= 0) {
-            // Target is in second quadrant
-            art_tar_deg = 360 - art_tar_deg;
-        }
-        else if (tar_coord.x < 0 && tar_coord.y < 0) {
-            // Target is in third quadrant
-            art_tar_deg = 180 + art_tar_deg;
-        }
-        else if (tar_coord.x >= 0 && tar_coord.y < 0) {
-            // Target is in fourth quadrant
-            art_tar_deg = 180 - art_tar_deg;
-        }
-
-        if (isNaN(art_tar_dist) || isNaN(art_tar_deg)) {
-            return {error: true};
-        }
-
-        return {art_tar_dist: art_tar_dist, art_tar_deg: art_tar_deg};
+        
+        // calculate distance and azimuth from the arty to its target
+        var result = inst.cartesianToPolar(art_coord.x, art_coord.y, tar_coord.x, tar_coord.y);
+        return {art_tar_dist: result.dist, art_tar_deg: result.azim};
     };
 
     return inst;

--- a/js/artycalc.js
+++ b/js/artycalc.js
@@ -33,6 +33,18 @@ var artycal = (function() {
     inst.get_backcourse = function(degrees) {
         return (degrees >= 180)? degrees-180 : degrees+180;;
     }
+    
+    // Calculate the length of the opposite angles side
+    // (ie: how long is the offset given an specific angle?)
+    inst.getOpAngleDist = function(distance, degrees) {
+        return distance * Math.tan(to_radians(degrees));
+    }
+    
+    // Calculate correction angle needed for a given dist
+    // (i.e. how many degrees to rotate to hit a corrected position)
+    inst.getCorrectionAngle = function(distanceToTGT, leftRightCorrection) {
+        return to_degrees(Math.atan(leftRightCorrection / distanceToTGT));
+    }
 
     /**
      * Foxhole only allows distance adjustments in 5 meter increments. Round number to the nearest multiple of five.

--- a/js/artycalc.js
+++ b/js/artycalc.js
@@ -30,6 +30,10 @@ var artycal = (function() {
         coords.y += matrix.y;
     }
 
+    inst.get_backcourse = function(degrees) {
+        return (degrees >= 180)? degrees-180 : degrees+180;;
+    }
+
     /**
      * Foxhole only allows distance adjustments in 5 meter increments. Round number to the nearest multiple of five.
      * @param num Number to round


### PR DESCRIPTION
This PR adds:
- the option to add TRPs (target reference points) in between the spotter and the arty piece, which will allow arbitary forward observer positions and lift the limit of binocs (both target and arty needed to be in range beforehand).
(fix #2)
- a small button next to the azimuth input fields to swap the current azimuth with its back course. This is helpful if you just got a forward bearing, but need a backwards one without needing to run over there (or pulling out the calculator).
(fix #3)
- A Firing plan feature, which allows the user to store and retrieve plans across sessions


DEMO: https://hbeni.github.io/foxhole-artillery-calc/